### PR TITLE
Switch from setuptools to pip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,13 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: python setup.py install  --single-version-externally-managed --record=record.txt
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
+    - pip
     - python
     - setuptools
   run:


### PR DESCRIPTION
Got a message from the linter stating that I should not use pip instead of setuptools. Trying this out.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
