### PR TITLE
Pin Pandas to <2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -26,7 +26,7 @@ requirements:
     - python >=3.7
     - matplotlib-base >=3.2.2
     - numpy >=1.10.1
-    - pandas >=1.0.0
+    - pandas >=1.0.0,<2.0
     - requests >=2.8.1
     - scipy >=1.0.0
     - pysoundfile >=0.10.0,<0.12.0


### PR DESCRIPTION
In the `wfdb` sdist, there is an upper bound for Pandas (<2.0). The `conda-forge` package currently doesn't have this bound set, leading to issues when trying to build other packages that depend on `wfdb` becuause `pip check` might fail, like here:

https://github.com/conda-forge/sleepecg-feedstock/pull/19#issuecomment-1506911625

This commit pins Pandas to <2.0 until the restriction is lifted upstream (see this issue: https://github.com/MIT-LCP/wfdb-python/issues/446)


* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
